### PR TITLE
Use standard comment headers

### DIFF
--- a/opam-mode.el
+++ b/opam-mode.el
@@ -113,7 +113,7 @@
   (setq mode-name "OPAM") )
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("/opam\\'" . opam-mode))
+(add-to-list 'auto-mode-alist '("\\(?:\\.\\|/\\)opam\\'" . opam-mode))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("/url\\'" . opam-url-mode))

--- a/opam-mode.el
+++ b/opam-mode.el
@@ -1,3 +1,12 @@
+;;; opam-mode.el --- mode for opam files
+
+;; Author: Julien Sagot <ju.sagot@gmail.com>
+;; Version: 0.1
+;; Keywords: opam, ocaml
+;; URL: https://github.com/sagotch/opam-mode.el
+;;
+;; This file is not part of GNU Emacs.
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;    The MIT License (MIT)    ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -23,6 +32,8 @@
 ;; TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ;; SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+;;; Commentary:
+
 ;;;;;;;;;;;;;;;;;;;;;;;
 ;;    Description    ;;
 ;;;;;;;;;;;;;;;;;;;;;;;
@@ -31,7 +42,7 @@
 
 ;; Sources and issue tracker: https://github.com/sagotch/opam-mode.el
 
-;; Version: 0.1
+;;; Code:
 
 ;;;;;;;;;;;;;;;;;;;;;
 ;;    opam-mode    ;;
@@ -108,3 +119,5 @@
 (add-to-list 'auto-mode-alist '("/url\\'" . opam-url-mode))
 
 (provide 'opam-mode)
+
+;;; opam-mode.el ends here

--- a/opam-mode.el
+++ b/opam-mode.el
@@ -3,7 +3,7 @@
 ;; Author: Julien Sagot <ju.sagot@gmail.com>
 ;; Version: 0.1
 ;; Keywords: opam, ocaml
-;; URL: https://github.com/sagotch/opam-mode.el
+;; Homepage: https://github.com/sagotch/opam-mode.el
 ;;
 ;; This file is not part of GNU Emacs.
 


### PR DESCRIPTION
Documented here:

https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html

With this chance, I'm able to use the package directly using
https://github.com/quelpa/quelpa/ for example.